### PR TITLE
add event tests for accepted and deleted actions

### DIFF
--- a/test/cases/events/event.json
+++ b/test/cases/events/event.json
@@ -305,5 +305,55 @@
       "ref_count": null
     },
     "author_username": "tmcgilchrist"
+  },
+  {
+    "id": 1517046373,
+    "project_id": 30561150,
+    "action_name": "deleted",
+    "target_id": null,
+    "target_iid": null,
+    "target_type": null,
+    "author_id": 9920770,
+    "target_title": null,
+    "created_at": "2021-10-18T21:13:24.836Z",
+    "author": {
+      "id": 9920770,
+      "name": "Patrick Ferris",
+      "username": "patrickferris",
+      "state": "active",
+      "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/9920770/avatar.png",
+      "web_url": "https://gitlab.com/patrickferris"
+    },
+    "push_data": {
+      "commit_count": 0,
+      "action": "removed",
+      "ref_type": "branch",
+      "commit_from": "c6917df5431ddd6e50e1f65d60e0c940614b0f48",
+      "commit_to": null,
+      "ref": "update-readme",
+      "commit_title": null,
+      "ref_count": null
+    },
+    "author_username": "patrickferris"
+  },
+  {
+    "id": 1517046361,
+    "project_id": 30561150,
+    "action_name": "accepted",
+    "target_id": 121831146,
+    "target_iid": 1,
+    "target_type": "MergeRequest",
+    "author_id": 9920770,
+    "target_title": "update readme",
+    "created_at": "2021-10-18T21:13:24.256Z",
+    "author": {
+      "id": 9920770,
+      "name": "Patrick Ferris",
+      "username": "patrickferris",
+      "state": "active",
+      "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/9920770/avatar.png",
+      "web_url": "https://gitlab.com/patrickferris"
+    },
+    "author_username": "patrickferris"
   }
 ]

--- a/test/cases/events/expected.json
+++ b/test/cases/events/expected.json
@@ -304,5 +304,55 @@
       "ref_count": null
     },
     "author_username": "tmcgilchrist"
+  },
+  {
+    "id": 1517046373,
+    "project_id": 30561150,
+    "action_name": "deleted",
+    "target_id": null,
+    "target_iid": null,
+    "target_type": null,
+    "author_id": 9920770,
+    "target_title": null,
+    "created_at": "2021-10-18T21:13:24.836Z",
+    "author": {
+      "id": 9920770,
+      "name": "Patrick Ferris",
+      "username": "patrickferris",
+      "state": "active",
+      "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/9920770/avatar.png",
+      "web_url": "https://gitlab.com/patrickferris"
+    },
+    "push_data": {
+      "commit_count": 0,
+      "action": "removed",
+      "ref_type": "branch",
+      "commit_from": "c6917df5431ddd6e50e1f65d60e0c940614b0f48",
+      "commit_to": null,
+      "ref": "update-readme",
+      "commit_title": null,
+      "ref_count": null
+    },
+    "author_username": "patrickferris"
+  },
+  {
+    "id": 1517046361,
+    "project_id": 30561150,
+    "action_name": "accepted",
+    "target_id": 121831146,
+    "target_iid": 1,
+    "target_type": "MergeRequest",
+    "author_id": 9920770,
+    "target_title": "update readme",
+    "created_at": "2021-10-18T21:13:24.256Z",
+    "author": {
+      "id": 9920770,
+      "name": "Patrick Ferris",
+      "username": "patrickferris",
+      "state": "active",
+      "avatar_url": "https://gitlab.com/uploads/-/system/user/avatar/9920770/avatar.png",
+      "web_url": "https://gitlab.com/patrickferris"
+    },
+    "author_username": "patrickferris"
   }
 ]


### PR DESCRIPTION
A follow up for #9 adding the output for my Gitlab that was causing some issues when parsing the events. I just copied it over to the expected output, I didn't quite follow the `jd` testing setup, but `dune runtest` passes :) 