### PR TITLE
dune-project: don't list dune as dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -14,7 +14,6 @@
  (name gitlab)
  (depends
   (ocaml (>= 4.08.0))
-  (dune (>= 1.10))
   (uri (>= 1.9.0))
   (cohttp-lwt (>= 4.0))
   (atdgen (>= 2.0.0))
@@ -31,7 +30,6 @@ JavaScript via [js_of_ocaml](http://ocsigen.org/js_of_ocaml)."))
  (name gitlab-unix)
  (depends
   (ocaml (>= 4.08.0))
-  (dune (>= 1.10))
   (gitlab (= :version))
   (cohttp (>= 4.0))
   (cohttp-lwt-unix (>= 4.0))

--- a/gitlab-unix.opam
+++ b/gitlab-unix.opam
@@ -12,8 +12,8 @@ homepage: "https://github.com/tmcgilchrist/ocaml-gitlab"
 doc: "https://tmcgilchrist.github.io/ocaml-gitlab/"
 bug-reports: "https://github.com/tmcgilchrist/ocaml-gitlab/issues"
 depends: [
+  "dune" {>= "2.9"}
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.9" & >= "1.10"}
   "gitlab" {= version}
   "cohttp" {>= "4.0"}
   "cohttp-lwt-unix" {>= "4.0"}

--- a/gitlab.opam
+++ b/gitlab.opam
@@ -14,8 +14,8 @@ homepage: "https://github.com/tmcgilchrist/ocaml-gitlab"
 doc: "https://tmcgilchrist.github.io/ocaml-gitlab/"
 bug-reports: "https://github.com/tmcgilchrist/ocaml-gitlab/issues"
 depends: [
+  "dune" {>= "2.9"}
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "2.9" & >= "1.10"}
   "uri" {>= "1.9.0"}
   "cohttp-lwt" {>= "4.0"}
   "atdgen" {>= "2.0.0"}


### PR DESCRIPTION
It is added automatically

Re generated opam files to pass CI. Replaces this https://github.com/tmcgilchrist/ocaml-gitlab/pull/36