### PR TITLE
Fix incorrect field name, detected with atdgen 2.3.x

### DIFF
--- a/lib/gitlab.atd
+++ b/lib/gitlab.atd
@@ -602,7 +602,7 @@ type label = {
   updated_at: string;
   template: bool;
   description: string;
-  label_type: string <json name="type">;
+  label_type <json name="type">: string;
   group_id: int;
 } <ocaml field_prefix="label_">
 


### PR DESCRIPTION
The atd annotation was misplaced. The JSON field name is now `"type"` rather than `"label_type"`. Atdgen 2.3.3 (soon to be released) detects this.