### PR TITLE
Add pipeline related APIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,12 @@
 ## Added
 
   * Depend on atd >= 2.8 to get codegen fixes. (#63 @MisterDA)
+  * Add endpoints `Project.pipeline`, `Project.pipeline_jobs` , `Project.job_trace` , `Project.pipelines`.
+  * Add param `updated_after` to `Project.merge_requests`
+
+## Bug fixes
+
+  * Make the field `source_project_id` of `merge_request` nullable
 
 # 0.1.4 - 2022-06-02
 

--- a/lib/gitlab.atd
+++ b/lib/gitlab.atd
@@ -345,7 +345,7 @@ type merge_request = {
   has_conflicts: bool;
   assignees: user_short list;
   reviewers: user_short list;
-  source_project_id: int;
+  source_project_id: int nullable;
   target_project_id: int;
   labels: string list;
   draft: bool;

--- a/lib/gitlab.atd
+++ b/lib/gitlab.atd
@@ -1318,3 +1318,49 @@ type create_project_hook = {
   ?wiki_page_events: bool option;
   ?token: string option;
 }
+
+type pipeline_status = [
+ | Created <json name="created">
+ | WaitingForResource <json name="waiting_for_resource">
+ | Preparing <json name="preparing">
+ | Pending <json name="pending">
+ | Running <json name="running">
+ | Success <json name="success">
+ | Failed <json name="failed">
+ | Canceled <json name="canceled">
+ | Skipped <json name="skipped">
+ | Manual <json name="manual">
+ | Scheduled <json name="scheduled">
+]
+
+type pipeline_source = [
+  | Push <json name="push">
+  | Web <json name="web">
+  | Trigger <json name="trigger">
+  | Schedule <json name="schedule">
+  | Api <json name="api">
+  | External <json name="external">
+  | Pipeline <json name="pipeline">
+  | Chat <json name="chat">
+  | Webide <json name="webide">
+  | Merge_Request_Event <json name="merge_request_event">
+  | External_Pull_Request_Event <json name="external_pull_request_event">
+  | Parent_Pipeline <json name="parent_pipeline">
+  | Ondemand_Dast_Scan <json name="ondemand_dast_scan">
+  | Ondemand_Dast_Validation <json name="ondemand_dast_validation">
+]
+
+type pipeline = {
+    id : int;
+    iid : int;
+    project_id : int;
+    status : pipeline_status;
+    source : pipeline_source;
+    ref : string;
+    sha : string;
+    web_url : string;
+    created_at : date_time;
+    updated_at : date_time;
+}
+
+type pipelines = pipeline list

--- a/lib/gitlab.atd
+++ b/lib/gitlab.atd
@@ -1364,3 +1364,47 @@ type pipeline = {
 }
 
 type pipelines = pipeline list
+
+type pipeline_job_scope = [
+ | Created <json name="created">
+ | Pending <json name="pending">
+ | Running <json name="running">
+ | Failed <json name="failed">
+ | Success <json name="success">
+ | Canceled <json name="canceled">
+ | Skipped <json name="skipped">
+ | Manual <json name="manual">
+]
+
+type pipeline_job_status = [
+ | Created <json name="created">
+ | Pending <json name="pending">
+ | Running <json name="running">
+ | Failed <json name="failed">
+ | Success <json name="success">
+ | Canceled <json name="canceled">
+ | Skipped <json name="skipped">
+ | Manual <json name="manual">
+]
+
+type pipeline_job_failure_reason = [
+ | Script_failure <json name="script_failure">
+ | Runner_system_failure <json name="runner_system_failure">
+ | Job_execution_timeout <json name="job_execution_timeout">
+ | Stuck_or_timeout_failure <json name="stuck_or_timeout_failure">
+ | Unknown_failure <json name="unknown_failure">
+]
+
+type pipeline_job = {
+    id : int;
+    name : string;
+    status : pipeline_job_status;
+    ?failure_reason : pipeline_job_failure_reason option;
+    ref : string;
+    web_url : string;
+    created_at : date_time nullable;
+    started_at : date_time nullable;
+    finished_at : date_time nullable;
+}
+
+type pipeline_jobs = pipeline_job list

--- a/lib/gitlab.atd
+++ b/lib/gitlab.atd
@@ -1365,6 +1365,21 @@ type pipeline = {
 
 type pipelines = pipeline list
 
+type single_pipeline = {
+    id : int;
+    iid : int;
+    project_id : int;
+    status : pipeline_status;
+    source : pipeline_source;
+    ref : string;
+    sha : string;
+    web_url : string;
+    started_at : date_time nullable;
+    created_at : date_time nullable;
+    updated_at : date_time nullable;
+    finished_at : date_time nullable;
+}
+
 type pipeline_job_scope = [
  | Created <json name="created">
  | Pending <json name="pending">

--- a/lib/gitlab_core.ml
+++ b/lib/gitlab_core.ml
@@ -1438,7 +1438,7 @@ struct
       API.get ~token ~uri ~fail_handlers (fun body -> return (Some body))
 
     let merge_requests ?token ?state ?milestone ?labels ?author ?author_username
-        ?my_reaction ?scope ~id () =
+        ?my_reaction ?scope ?updated_after ~id () =
       let uri =
         URI.project_merge_requests ~id
         |> state_param state |> milestone_param milestone |> labels_param labels
@@ -1446,6 +1446,7 @@ struct
         |> author_username_param author_username
         |> my_reaction_param my_reaction
         |> scope_param scope
+        |> updated_after_param updated_after
       in
       API.get_stream ?token ~uri (fun body ->
           return (Gitlab_j.merge_requests_of_string body))

--- a/lib/gitlab_core.ml
+++ b/lib/gitlab_core.ml
@@ -241,6 +241,10 @@ struct
     let project_pipelines ~id =
       Uri.of_string (Printf.sprintf "%s/projects/%i/pipelines" api id)
 
+    let project_job_trace id ~job_id =
+      Uri.of_string
+        (Printf.sprintf "%s/projects/%i/jobs/%d/trace" api id job_id)
+
     let project_events ~id =
       Uri.of_string (Printf.sprintf "%s/projects/%i/events" api id)
 
@@ -1378,6 +1382,13 @@ struct
       in
       API.get_stream ~token ~uri (fun body ->
           return (Gitlab_j.pipelines_of_string body))
+
+    let job_trace ~token ~project_id ~job_id () =
+      let uri = URI.project_job_trace project_id ~job_id in
+      let fail_handlers =
+        [ API.code_handler ~expected_code:`Not_found (fun _ -> return None) ]
+      in
+      API.get ~token ~uri ~fail_handlers (fun body -> return (Some body))
 
     let merge_requests ?token ?state ?milestone ?labels ?author ?author_username
         ?my_reaction ?scope ~id () =

--- a/lib/gitlab_core.ml
+++ b/lib/gitlab_core.ml
@@ -238,6 +238,10 @@ struct
         (Printf.sprintf "%s/projects/%i/merge_requests/%s/notes/%i" api project_id
            merge_request_iid note_id)
 
+    let project_pipeline ~id ~pipeline_id =
+      Uri.of_string
+        (Printf.sprintf "%s/projects/%i/pipelines/%i" api id pipeline_id)
+
     let project_pipelines ~id =
       Uri.of_string (Printf.sprintf "%s/projects/%i/pipelines" api id)
 
@@ -1381,6 +1385,11 @@ struct
       in
       API.get ?token ~uri ~fail_handlers (fun body ->
           return (Some (Gitlab_j.project_short_of_string body)))
+
+    let pipeline ~token ~project_id ~pipeline_id () =
+      let uri = URI.project_pipeline ~id:project_id ~pipeline_id in
+      API.get ~token ~uri (fun body ->
+          return (Gitlab_j.single_pipeline_of_string body))
 
     let pipelines ~token ~project_id ?per_page ?status ?source ?sha ?ref_
         ?username ?updated_after ?updated_before ?sort ?order_by () =

--- a/lib/gitlab_s.mli
+++ b/lib/gitlab_s.mli
@@ -623,6 +623,21 @@ module type Gitlab = sig
         See {{:https://docs.gitlab.com/ee/api/pipelines.html#list-project-pipelines}List project pipelines}.
      *)
 
+    val pipeline_jobs :
+      token:Token.t ->
+      project_id:int ->
+      ?per_page:int ->
+      ?scope:Gitlab_t.pipeline_job_scope ->
+      ?include_retried:bool ->
+      pipeline_id:int ->
+      unit ->
+      Gitlab_t.pipeline_job Stream.t
+    (** [pipeline_jobs ~token ~project_id pipeline_id ()] get a list of jobs for
+        a pipeline [pipeline_id] of a project [project_id].
+
+        See {{:https://docs.gitlab.com/ee/api/jobs.html#list-pipeline-jobs}List pipeline jobs}.
+     *)
+
     val job_trace :
       token:Token.t ->
       project_id:int ->

--- a/lib/gitlab_s.mli
+++ b/lib/gitlab_s.mli
@@ -603,6 +603,26 @@ module type Gitlab = sig
        *)
     end
 
+    val pipelines :
+      token:Token.t ->
+      project_id:int ->
+      ?per_page:int ->
+      ?status:Gitlab_t.pipeline_status ->
+      ?source:Gitlab_t.pipeline_source ->
+      ?sha:string ->
+      ?ref_:string ->
+      ?username:string ->
+      ?updated_after:string ->
+      ?updated_before:string ->
+      ?sort:Gitlab_t.sort ->
+      ?order_by:[`Id | `Ref | `Status | `Updated_at | `User_id ] ->
+      unit ->
+      Gitlab_t.pipeline Stream.t
+    (** [pipelines ~token ~project_id ()] list all pipelines the authenticated user has access to in [project_id].
+
+        See {{:https://docs.gitlab.com/ee/api/pipelines.html#list-project-pipelines}List project pipelines}.
+     *)
+
     val merge_requests :
       ?token:Token.t ->
       ?state:Gitlab_t.state ->

--- a/lib/gitlab_s.mli
+++ b/lib/gitlab_s.mli
@@ -623,6 +623,17 @@ module type Gitlab = sig
         See {{:https://docs.gitlab.com/ee/api/pipelines.html#list-project-pipelines}List project pipelines}.
      *)
 
+    val pipeline :
+      token:Token.t ->
+      project_id:int ->
+      pipeline_id:int ->
+      unit ->
+      Gitlab_t.single_pipeline Response.t Monad.t
+    (** [pipeline ~token ~project_id ~pipeline_id ()] get one single pipeline [pipeline_id] in [project_id].
+
+        See {{:https://docs.gitlab.com/ee/api/pipelines.html#get-a-single-pipeline} Get a single pipeline}.
+     *)
+
     val pipeline_jobs :
       token:Token.t ->
       project_id:int ->

--- a/lib/gitlab_s.mli
+++ b/lib/gitlab_s.mli
@@ -623,6 +623,18 @@ module type Gitlab = sig
         See {{:https://docs.gitlab.com/ee/api/pipelines.html#list-project-pipelines}List project pipelines}.
      *)
 
+    val job_trace :
+      token:Token.t ->
+      project_id:int ->
+      job_id:int ->
+      unit ->
+      string option Response.t Monad.t
+    (** [job_trace ~token ~project_id job_id ()] get the log (trace) of a
+        specific job [job_id] of a project [project-id].
+
+        See {{:https://docs.gitlab.com/ee/api/jobs.html#get-a-log-file}Get a log file}.
+     *)
+
     val merge_requests :
       ?token:Token.t ->
       ?state:Gitlab_t.state ->

--- a/lib/gitlab_s.mli
+++ b/lib/gitlab_s.mli
@@ -670,6 +670,7 @@ module type Gitlab = sig
       ?author_username:string ->
       ?my_reaction:string ->
       ?scope:Gitlab_t.merge_request_scope ->
+      ?updated_after:string ->
       id:int ->
       unit ->
       Gitlab_t.merge_request Stream.t


### PR DESCRIPTION
 - Add 4 pipeline related API endpoints:
      
      - ecff279 * Add Project.pipeline
      - 459f682 * Add Project.pipeline_jobs
      - 615b528 * Add Project.job_trace
      - eb8e3fa * Add Project.pipelines

 - Add the param `updated_after` to `Project.merge_requests`
 - Set the field `source_project_id` of `merge_request` to nullable
   - this field is null when the source project has been removed