### PR TITLE
RFC/WIP: various more tweaks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,20 @@
 
 ## Added
 
+ * `gitlab.atd`: use `date_time` instead of strings for `_at` fields
+ * `Project`: add `merge_request_pipelines`
+ * `Project.merge_requests`: add parameters `updated_after`, `updated_before`,
+   `created_after`, `created_before` and `order_by`
+
+## Bug fixes
+
+ * `Project.pipeline_jobs`: 404 means pending pipeline, not error
+ * `gitlab.atd`: `time_stats` estimates are strings
+
+# 0.1.5 - 2022-06-17
+
+## Added
+
   * Depend on atd >= 2.8 to get codegen fixes. (#63 @MisterDA)
   * Add endpoints `Project.pipeline`, `Project.pipeline_jobs` , `Project.job_trace` , `Project.pipelines`.
   * Add param `updated_after` to `Project.merge_requests`

--- a/lib/gitlab.atd
+++ b/lib/gitlab.atd
@@ -297,8 +297,8 @@ type references = {
 type time_stats = {
   time_estimate: int;
   total_time_spent: int;
-  human_time_estimate: int nullable;
-  human_total_time_spent: int nullable;
+  human_time_estimate: string nullable;
+  human_total_time_spent: string nullable;
 } <ocaml field_prefix="time_stats_">
 
 type task_completion_status = {

--- a/lib/gitlab.atd
+++ b/lib/gitlab.atd
@@ -327,9 +327,9 @@ type merge_request = {
   description: string;
   state: state;
   merged_by: user_short nullable;
-  merged_at: string nullable;
+  merged_at: date_time nullable;
   closed_by: user_short nullable;
-  closed_at: string nullable;
+  closed_at: date_time nullable;
   created_at: date_time;
   updated_at: date_time;
   target_branch: string;
@@ -542,7 +542,7 @@ type issue = {
   state: state;
   created_at: date_time;
   updated_at: date_time;
-  closed_at: string nullable;
+  closed_at: date_time nullable;
   closed_by: user_short nullable;
   labels: string list;
   milestone: string nullable;
@@ -574,7 +574,7 @@ type issue = {
 
 type note_issue = {
   author_id: int;
-  closed_at: string nullable;
+  closed_at: date_time nullable;
   confidential: bool;
   created_at: date_time;
   description: string;
@@ -582,7 +582,7 @@ type note_issue = {
   due_date: date nullable;
   id: int;
   iid: int;
-  last_edited_at: string nullable;
+  last_edited_at: date_time nullable;
   last_edited_by_id: int nullable;
   milestone_id: int nullable;
   moved_to_id: string nullable;
@@ -642,7 +642,7 @@ type merge_request_attributes = {
   head_pipeline_id: int nullable;
   id: int;
   iid: int;
-  last_edited_at: string nullable;
+  last_edited_at: date_time nullable;
   last_edited_by_id: int nullable;
   last_commit: commit_short_webhook;
   ?oldrev: string option;
@@ -762,7 +762,7 @@ type issue_attributes = {
   assignee_id: int nullable;
   assignee_ids: int list;
   author_id: int;
-  closed_at: string nullable;
+  closed_at: date_time nullable;
   confidential: bool;
   created_at: date_time;
   description: string;
@@ -775,7 +775,7 @@ type issue_attributes = {
   id: int;
   iid: int;
   labels: string list;
-  last_edited_at: string nullable;
+  last_edited_at: date_time nullable;
   last_edited_by_id: int nullable;
   milestone_id: int nullable;
   moved_to_id: int nullable;
@@ -820,7 +820,7 @@ type note_attributes = {
   original_position: string nullable;
   position: string nullable;
   project_id: int;
-  resolved_at: string nullable;
+  resolved_at: date_time nullable;
   resolved_by_id: string nullable;
   resolved_by_push: string nullable;
   st_diff: string nullable;

--- a/lib/gitlab_core.ml
+++ b/lib/gitlab_core.ml
@@ -228,6 +228,11 @@ struct
         (Printf.sprintf "%s/projects/%i/merge_requests/%s/changes" api id
            merge_request_iid)
 
+    let project_merge_request_pipelines ~id ~merge_request_iid =
+      Uri.of_string
+        (Printf.sprintf "%s/projects/%i/merge_requests/%d/pipelines" api id
+           merge_request_iid)
+
     let project_merge_request_notes ~project_id ~merge_request_iid =
       Uri.of_string
         (Printf.sprintf "%s/projects/%i/merge_requests/%s/notes" api project_id
@@ -1511,6 +1516,13 @@ struct
         URI.project_merge_request_changes ~id:project_id ~merge_request_iid
       in
       API.get ?token ~uri (fun body -> return (Gitlab_j.changes_of_string body))
+
+    let merge_request_pipelines ?token ~project_id ~merge_request_iid () =
+      let uri =
+        URI.project_merge_request_pipelines ~id:project_id ~merge_request_iid
+      in
+      API.get_stream ?token ~uri (fun body ->
+          return (Gitlab_j.pipelines_of_string body))
 
     let events ~token ~project_id ?action ?target_type () =
       let uri =

--- a/lib/gitlab_core.ml
+++ b/lib/gitlab_core.ml
@@ -1455,7 +1455,10 @@ struct
         |> pipeline_job_scope_param scope
         |> pipeline_job_include_retried_param include_retried
       in
-      API.get_stream ~token ~uri (fun body ->
+      let fail_handlers =
+        [ API.code_handler ~expected_code:`Not_found (fun _ -> return []) ]
+      in
+      API.get_stream ~fail_handlers ~token ~uri (fun body ->
           return (Gitlab_j.pipeline_jobs_of_string body))
 
     let job_trace ~token ~project_id ~job_id () =

--- a/lib/gitlab_s.mli
+++ b/lib/gitlab_s.mli
@@ -732,6 +732,18 @@ module type Gitlab = sig
        See {{:https://docs.gitlab.com/ee/api/merge_requests.html#get-single-mr-changes}Get single MR changes}.
     *)
 
+    val merge_request_pipelines :
+      ?token:Token.t ->
+      project_id:int ->
+      merge_request_iid:int ->
+      unit ->
+      Gitlab_t.pipeline Stream.t
+    (** [merge_request_pipelines ?token ~project_id ~merge_request_iid ()] gets a list of merge request pipelines.
+
+       See {{:https://docs.gitlab.com/ee/api/merge_requests.html#list-mr-pipelines}List MR pipelines }.
+    *)
+
+
     val events :
       token:Token.t ->
       project_id:int ->

--- a/lib/gitlab_s.mli
+++ b/lib/gitlab_s.mli
@@ -216,6 +216,10 @@ module type Gitlab = sig
     (** [map f s] is the lazy stream of [f] applied to elements of [s]
         as they are demanded. *)
 
+    val take : int -> 'a t -> 'a t
+    (** [take n s] is the lazy stream of the first [n] elements of [s]
+        as they are demanded. *)
+
     val fold : ('a -> 'b -> 'a Monad.t) -> 'a -> 'b t -> 'a Monad.t
     (** [fold f a s] is the left fold of [f] over the elements of [s]
         with a base value of [a]. {b Warning:} this function may

--- a/lib/gitlab_s.mli
+++ b/lib/gitlab_s.mli
@@ -674,7 +674,12 @@ module type Gitlab = sig
       ?author_username:string ->
       ?my_reaction:string ->
       ?scope:Gitlab_t.merge_request_scope ->
+      ?created_after:string ->
+      ?created_before:string ->
       ?updated_after:string ->
+      ?updated_before:string ->
+      ?sort:Gitlab_t.sort ->
+      ?order_by:[`Created_at | `Title | `Updated_at ] ->
       id:int ->
       unit ->
       Gitlab_t.merge_request Stream.t


### PR DESCRIPTION
Some various tweaks. Sorry for submitting such "batch MRs" but i tend to add tweaks here and there when using the lib to write scripts. Then I submit the batch of tweaks when I get a chance. 

I think most changes here are obvious but some commentary:

+ * `Project.pipeline_jobs`: 404 means pending pipeline, not error

i'm not sure this is the correct way to do things

+ * `gitlab.atd`: `time_stats` estimates are strings

indeed, the estimates can be something like `"4 days"` or so. here's an example:

```
$ curl -s 'https://gitlab.com/api/v4/projects/tezos%2Ftezos/merge_requests/5876' | jq '.time_stats.human_time_estimate'
"112h"
```

looking in gitlab.atd i see other suspicious entries:

```
11 matches for "human_" in buffer: gitlab.atd
    300:  human_time_estimate: string nullable;
    301:  human_total_time_spent: string nullable;
    601:  human_total_time_spent: int nullable;
    602:  human_time_change: int nullable;
    603:  human_time_estimate: int nullable;
    672:  human_total_time_spent: int nullable;
    673:  human_time_change: int nullable;
    674:  human_time_estimate: int nullable;
    772:  human_time_change:string nullable;
    773:  human_time_estimate:string nullable;
    774:  human_total_time_spent:string nullable;
``` 

but I'm not sure there . i'll happily change them all to `string nullable` if you think it is correct :) 

---

didn't forget to update `CHANGES.md` this time -- i noticed that a section for 0.1.5 had not been created yet so I did so :)