### PR TITLE
Add Job_artifacts endpoints and commands

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+## Added
+
+ * Added `Artifacts` module
+ * Added `artifact` commands to `lab` cli client
+
 # 0.1.6 - 2022-11-08
 
 ## Added

--- a/cli/dune
+++ b/cli/dune
@@ -2,7 +2,7 @@
  (libraries cohttp-lwt-unix gitlab-unix cmdliner otoml fmt)
  (package lab)
  (public_name lab)
- (modules main api config issue merge_request project user runner project_hook)
+ (modules main api config issue merge_request project user runner project_hook job_artifact)
  (name main))
 
 (mdx

--- a/cli/job_artifact.ml
+++ b/cli/job_artifact.ml
@@ -1,0 +1,156 @@
+open Cmdliner
+open Printf
+open Config
+
+let envs = Gitlab.Env.envs
+
+let project_id =
+  let doc = "Project Id" in
+  Arg.(
+    required
+    & opt (some int) None
+    & info [ "p"; "project-id" ] ~docv:"PROJECT_ID" ~doc)
+
+let job_id =
+  let doc = "Job Id" in
+  Arg.(
+    required & opt (some int) None & info [ "j"; "job-id" ] ~docv:"JOB_ID" ~doc)
+
+let job_token =
+  let doc = "Job Token" in
+  Arg.(
+    value
+    & opt (some string) None
+    & info [ "t"; "job-token" ] ~docv:"JOB_TOKEN" ~doc)
+
+let ref_name =
+  let doc =
+    "Branch or tag name in repository. HEAD or SHA references are not supported"
+  in
+  Arg.(
+    required
+    & opt (some string) None
+    & info [ "r"; "ref-name" ] ~docv:"REF_NAME" ~doc)
+
+let job_name =
+  let doc = "The name of the job" in
+  Arg.(
+    required
+    & opt (some string) None
+    & info [ "n"; "job-name" ] ~docv:"JOB_NAME" ~doc)
+
+let artifact_path =
+  let doc = "Artifact path" in
+  Arg.(
+    required
+    & opt (some string) None
+    & info [ "a"; "artifact-path" ] ~docv:"ARTIFACT_PATH" ~doc)
+
+let output_file =
+  let doc = "Output file" in
+  Arg.(
+    value
+    & opt (some string) None
+    & info [ "o"; "output-file" ] ~docv:"OUTPUT_FILE" ~doc)
+
+let with_open_out file write_f =
+  let chan = open_out file in
+  try
+    write_f chan;
+    close_out chan
+  with x ->
+    close_out chan;
+    raise x
+
+let write_file filename ~contents =
+  with_open_out filename @@ fun ch -> output_string ch contents
+
+let write_response_to_file ~output_file response =
+  match response with
+  | None -> printf "Found no artifact\n"
+  | Some artifact ->
+      write_file output_file ~contents:artifact;
+      printf "Wrote %s\n" output_file
+
+let get_cmd config =
+  let get job_token project_id job_id output_file =
+    let cmd =
+      let open Gitlab in
+      let open Monad in
+      let config = config () in
+      let output_file =
+        let default =
+          Format.asprintf "job-artifacts-%d-%d.zip" project_id job_id
+        in
+        Option.value ~default output_file
+      in
+      Job_artifacts.get ~token:config.token ?job_token ~project_id ~job_id ()
+      >|~ write_response_to_file ~output_file
+    in
+    Lwt_main.run @@ Gitlab.Monad.run cmd
+  in
+  let doc = "Download a job's artifacts as a zip-file" in
+  let info = Cmd.info ~envs ~doc "get" in
+  let term = Term.(const get $ job_token $ project_id $ job_id $ output_file) in
+  Cmd.v info term
+
+let get_archive_cmd config =
+  let get_archive job_token project_id ref_name job_name output_file =
+    let cmd =
+      let open Gitlab in
+      let open Monad in
+      let config = config () in
+      let output_file =
+        let default =
+          Format.asprintf "job-artifacts-%d-%s-%s.zip" project_id ref_name
+            job_name
+        in
+        Option.value ~default output_file
+      in
+      Job_artifacts.get_archive ~token:config.token ?job_token ~project_id
+        ~ref_name ~job:job_name ()
+      >|~ write_response_to_file ~output_file
+    in
+    Lwt_main.run @@ Gitlab.Monad.run cmd
+  in
+  let doc = "Download a job's artifacts as a zip-file" in
+  let info = Cmd.info ~envs ~doc "get_archive" in
+  let term =
+    Term.(
+      const get_archive $ job_token $ project_id $ ref_name $ job_name
+      $ output_file)
+  in
+  Cmd.v info term
+
+let get_file_cmd config =
+  let get_file job_token project_id job_id artifact_path output_file =
+    let cmd =
+      let open Gitlab in
+      let open Monad in
+      let config = config () in
+      let output_file =
+        let default = Filename.basename artifact_path in
+        Option.value ~default output_file
+      in
+      Job_artifacts.get_file ~token:config.token ?job_token ~project_id ~job_id
+        ~artifact_path ()
+      >|~ write_response_to_file ~output_file
+    in
+    Lwt_main.run @@ Gitlab.Monad.run cmd
+  in
+  let doc = "Download a job's artifacts as a zip-file" in
+  let info = Cmd.info ~envs ~doc "get_file" in
+  let term =
+    Term.(
+      const get_file $ job_token $ project_id $ job_id $ artifact_path
+      $ output_file)
+  in
+  Cmd.v info term
+
+let cmd config =
+  let doc = "Work with GitLab artifacts." in
+  let default = Term.(ret (const (`Help (`Pager, None)))) in
+  let man = [] in
+  let info = Cmd.info ~envs "artifact" ~doc ~man in
+  Cmd.group ~default info
+    [ get_cmd config; get_archive_cmd config; get_file_cmd config ]

--- a/cli/main.ml
+++ b/cli/main.ml
@@ -24,6 +24,7 @@ let cmds =
   [
     Api.cmd config;
     Issue.cmd config;
+    Job_artifact.cmd config;
     Merge_request.cmd config;
     Project.cmd config;
     User.cmd config;

--- a/lib/gitlab_s.mli
+++ b/lib/gitlab_s.mli
@@ -272,6 +272,7 @@ module type Gitlab = sig
     val get :
       ?fail_handlers:'a parse handler list ->
       ?expected_code:Cohttp.Code.status_code ->
+      ?media_type:string ->
       ?headers:Cohttp.Header.t ->
       ?token:Token.t ->
       ?params:(string * string) list ->

--- a/lib/gitlab_s.mli
+++ b/lib/gitlab_s.mli
@@ -1309,6 +1309,43 @@ module type Gitlab = sig
       Gitlab_t.runners Response.t Monad.t
     (** [list ~token] Get a list of specific runners available to the user.*)
   end
+
+  (** The [Job Artifacts] module provides access to {{:https://docs.gitlab.com/ee/api/job_artifacts.html}Job Artifacts API}.
+  *)
+  module Job_artifacts : sig
+    val get :
+      ?token:Token.t ->
+      project_id:int ->
+      job_id:int ->
+      ?job_token:string ->
+      unit ->
+      string option Response.t Monad.t
+    (** [artifacts ~project_id ~job_id ()] Get the job’s artifacts zipped archive of a project. *)
+
+    val get_archive :
+      ?token:Token.t ->
+      project_id:int ->
+      ref_name:string ->
+      job:string ->
+      ?job_token:string ->
+      unit ->
+      string option Response.t Monad.t
+    (** [archive ~project-id ~ref_name ~job] Download the artifacts zipped archive from
+        the latest successful pipeline for the given reference name [ref_name]
+        and [job], provided the job finished successfully.  *)
+
+    val get_file :
+      ?token:Token.t ->
+      project_id:int ->
+      job_id:int ->
+      artifact_path:string ->
+      ?job_token:string ->
+      unit ->
+      string option Response.t Monad.t
+    (** [archive ~project-id ~ref_name ~job] Download a single
+        artifact file from a [job_id] from inside the job’s artifacts
+        zipped archive.  *)
+  end
 end
 
 (** A module of this type is required in order to construct a


### PR DESCRIPTION
Adds the `Job_artifacts` module and implements three endpoints from https://docs.gitlab.com/ee/api/job_artifacts.html

Updated the `lab` tool with corresponding commands.

To do this, I had to expose the `media_type` argument of `API.get`. 