### PR TITLE
Make description nullable in project

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Bug fixes
+
+ * `gitlab.atd`: `description` is nullable (#75 @maiste)
+
 # 0.1.6 - 2022-11-08
 
 ## Added

--- a/lib/gitlab.atd
+++ b/lib/gitlab.atd
@@ -125,7 +125,7 @@ type visibility = [
 type project_short = {
   id: int;
   name: string;
-  description: string;
+  description: string nullable;
   name_with_namespace: string;
   path: string;
   path_with_namespace: string;


### PR DESCRIPTION
This is something that crash `ocaml-ci` if we don't have a nullable field in the description. This is allowed according to this example: https://docs.gitlab.com/ee/api/projects.html#list-all-projects .