### PR TITLE
Add OCaml 4.14/5.x builds for Windows.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,18 +12,12 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-12
-          - ubuntu-22.04
           - windows-2022
 
         ocaml-compiler:
-          - 4.08.x
-          # - 4.09.x
-          # - 4.10.x
-          # - 4.11.x
-          # - 4.12.x
-          - 4.13.x
-          - 4.14.x
+          - "ocaml-variants.4.14.1+mingw64c"
+          - "ocaml.5.0.0,ocaml-option-mingw"
+          - "ocaml.5.1.0,ocaml-option-mingw"
 
     runs-on: ${{ matrix.os }}
 
@@ -35,6 +29,10 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          opam-repositories: |
+             dra27: https://github.com/dra27/opam-repository.git#windows-5.0
+             default: https://github.com/ocaml-opam/opam-repository-mingw.git#sunset
+             standard: https://github.com/ocaml/opam-repository.git
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
Add OCaml 4.14 and 5.x builds for Windows 2022 on GH Actions. This PR removes GH Actions builds for Linux and macOS since they are provided by [ocaml.ci.dev](https://ocaml.ci.dev). 