### PR TITLE
RFC: Stream: add total

### DIFF
--- a/lib/gitlab_s.mli
+++ b/lib/gitlab_s.mli
@@ -214,6 +214,8 @@ module type Gitlab = sig
         means to iterate over ordered API results which may be too
         numerous to fit into a single request/response pair. *)
 
+    val total : 'a t -> int option
+
     val map : ('a -> 'b list Monad.t) -> 'a t -> 'b t
     (** [map f s] is the lazy stream of [f] applied to elements of [s]
         as they are demanded. *)


### PR DESCRIPTION
This code shouldn't be merged. However, posting it to get some comments. For a given use case, I needed to know the total number of items for a given paginated stream, without requesting all items in the stream (being very long). The ugly thing about the hack to this end in this PR is that you have to get the first element of the stream (by calling `Stream.next`) before `Stream.total` becomes available. 

Nicer solutions could be: 

 - Having `Stream.total` force the stream
 - Changing the type of `Stream.t` so that the user has to provide a function that returns the total number of elements in the stream. When creating a `Stream.t` from GitLab API requests, this function can do e.g. an HTTP HEAD on the API endpoint to get the total number. 

Any ideas?